### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fmanuel809/outlook-events-client/security/code-scanning/1](https://github.com/Fmanuel809/outlook-events-client/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
1. The `softprops/action-gh-release@v2` step likely requires `contents: write` to create a release and upload files.
2. Other steps, such as `actions/checkout@v4` and `actions/setup-node@v4`, do not require additional permissions beyond `contents: read`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as this workflow has only one job (`release`). This ensures clarity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
