### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: Publish to npm
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/Fmanuel809/outlook-events-client/security/code-scanning/2](https://github.com/Fmanuel809/outlook-events-client/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow involves publishing to npm, it requires `contents: read` to access the repository's contents and `packages: write` to publish the package. These permissions will be explicitly defined to prevent the workflow from inheriting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
