### PR TITLE
Fix authProvider variable name

### DIFF
--- a/src/utils/create-graph-client.ts
+++ b/src/utils/create-graph-client.ts
@@ -19,9 +19,9 @@ export const createGraphClient = (credentials: IClientCredential): Client => {
     const { clientId, clientSecret, tenantId } = credentials;
     const credentialProvider = new ClientSecretCredential(tenantId || "", clientId, clientSecret);
 
-    const authPRovider = new TokenCredentialAuthenticationProvider(credentialProvider, {
+    const authProvider = new TokenCredentialAuthenticationProvider(credentialProvider, {
         scopes: ["https://graph.microsoft.com/.default"]
     });
 
-    return Client.initWithMiddleware({ authProvider: authPRovider });
+    return Client.initWithMiddleware({ authProvider });
 }


### PR DESCRIPTION
## Summary
- correct typo in createGraphClient

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840591ebda4832a8d941b6a5fd3ca44