### PR TITLE
Add test for default scopes

### DIFF
--- a/tests/utils/create-graph-client.test.ts
+++ b/tests/utils/create-graph-client.test.ts
@@ -48,9 +48,10 @@ describe('createGraphClient', () => {
       tenantId: mockTenantId
     });
 
-    expect(TokenCredentialAuthenticationProvider).toHaveBeenCalled();
-    const [, options] = providerArgs[0];
-    expect(options).toEqual({ scopes: ['https://graph.microsoft.com/.default'] });
+    expect(TokenCredentialAuthenticationProvider).toHaveBeenCalledWith(
+      expect.any(ClientSecretCredential),
+      { scopes: ['https://graph.microsoft.com/.default'] }
+    );
   });
 
   it('should throw an error if credentials are missing', () => {

--- a/tests/utils/create-graph-client.test.ts
+++ b/tests/utils/create-graph-client.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { createGraphClient } from '../../src/utils';
 import { Client } from '@microsoft/microsoft-graph-client';
 import { ClientSecretCredential } from '@azure/identity';
+
+// Capture constructor arguments of TokenCredentialAuthenticationProvider
+const providerArgs: unknown[][] = [];
+vi.mock('@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials', () => ({
+  TokenCredentialAuthenticationProvider: vi.fn().mockImplementation((...args: unknown[]) => {
+    providerArgs.push(args);
+    return {};
+  })
+}));
+
+import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials';
+import { createGraphClient } from '../../src/utils';
 
 type FakeToken = { token: string; expiresOnTimestamp: number };
 
@@ -28,6 +39,18 @@ describe('createGraphClient', () => {
       tenantId: mockTenantId
     });
     expect(client).toBeInstanceOf(Client);
+  });
+
+  it('should instantiate TokenCredentialAuthenticationProvider with default scopes', () => {
+    createGraphClient({
+      clientId: mockClientId,
+      clientSecret: mockClientSecret,
+      tenantId: mockTenantId
+    });
+
+    expect(TokenCredentialAuthenticationProvider).toHaveBeenCalled();
+    const [, options] = providerArgs[0];
+    expect(options).toEqual({ scopes: ['https://graph.microsoft.com/.default'] });
   });
 
   it('should throw an error if credentials are missing', () => {


### PR DESCRIPTION
## Summary
- mock `TokenCredentialAuthenticationProvider` constructor in test
- assert provider constructed with Microsoft Graph default scope

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405932f7d0832a9e07ee559a87fd62