### PR TITLE
Fix event docs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Creates a client instance.
 
 Creates a calendar event for the specified user.
 
-- `event`: Object with event data (see example and types in `src/interfaces/outlook-event.ts`).
+- `event`: Object with event data (see example and types in `src/interfaces/event.ts`).
 - `userPrincipalName`: User's email or UPN.
 - **Errors:** Throws if parameters are invalid or the API fails.
 


### PR DESCRIPTION
## Summary
- fix README createEvent path

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405930764c832a83a01b3002580288