### PR TITLE
Fix event body contentType union

### DIFF
--- a/src/interfaces/event.ts
+++ b/src/interfaces/event.ts
@@ -47,7 +47,7 @@ export interface IEvent {
      * The type of content in the body (HTML or plain text).
      * @example 'HTML'
      */
-    contentType: 'HTML' | 'Text';
+    contentType: 'text' | 'html';
     /**
      * The actual content of the event body.
      * @example '<p>Discuss project updates</p>'


### PR DESCRIPTION
## Summary
- fix casing in `IEvent.body.contentType`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684059216d34832a90c5c74611a9427d